### PR TITLE
Updates base image and dependencies

### DIFF
--- a/mpd/CHANGELOG.md
+++ b/mpd/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 3.0.0 - 2026-02-06
+
+* 🔼 Updated alpine image to `3.23`
+* 🔼 Updated mpd to `0.24.8-r0`
+* 🔼 Updated myMPD to `23.0.1-r0`
+* 🔼 Updated upmpdcli to `1.9.7-r0`
+
+
 ## 2.1.0 - 2025-07-26
 
 * 🔼 Add DLNA Server/Renderer and Bridge upmpdcli

--- a/mpd/build.yaml
+++ b/mpd/build.yaml
@@ -5,12 +5,12 @@ build_from:
   amd64: ghcr.io/home-assistant/amd64-base:3.22
   i386: ghcr.io/home-assistant/i386-base:3.22
 
-#https://pkgs.alpinelinux.org/packages?name=mpc&branch=v3.22&repo=&arch=&origin=&flagged=&maintainer=
-#https://pkgs.alpinelinux.org/packages?name=mpd&branch=v3.22&repo=&arch=&origin=&flagged=&maintainer=
-#https://pkgs.alpinelinux.org/packages?name=mympd&branch=v3.22&repo=&arch=&origin=&flagged=&maintainer=
-#https://pkgs.alpinelinux.org/packages?name=upmpdcli&branch=v3.22&repo=&arch=&origin=&flagged=&maintainer=
+#https://pkgs.alpinelinux.org/packages?name=mpc&branch=v3.23&repo=&arch=&origin=&flagged=&maintainer=
+#https://pkgs.alpinelinux.org/packages?name=mpd&branch=v3.23&repo=&arch=&origin=&flagged=&maintainer=
+#https://pkgs.alpinelinux.org/packages?name=mympd&branch=v3.23&repo=&arch=&origin=&flagged=&maintainer=
+#https://pkgs.alpinelinux.org/packages?name=upmpdcli&branch=v3.23&repo=&arch=&origin=&flagged=&maintainer=
 args:
   MPC_VERSION: "0.35-r0"
-  MPD_VERSION: "0.24.4-r1"
-  MYMPD_VERSION: "21.0.0-r0"
-  UPMPDCLI_VERSION: "1.9.6-r0"
+  MPD_VERSION: "0.24.8-r0"
+  MYMPD_VERSION: "23.0.1-r0"
+  UPMPDCLI_VERSION: "1.9.7-r0"

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,3 +1,3 @@
-name: "rw-django-fan-2020 addons repository 2.0.0"
+name: "rw-django-fan-2020 addons repository 2.1.0"
 url: "https://github.com/rw-django-fan-2020/hassio-addons"
 maintainer: "rw-django-fan-2020"


### PR DESCRIPTION
Updates the Alpine base image to 3.23 and updates dependent packages: MPD, myMPD, and upmpdcli. This brings the addon up to latest versions.
Also updates the repository version.